### PR TITLE
Rename LinguaFlow references to Palabrita

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -29,7 +29,7 @@ const App: React.FC = () => {
   
   const [userProgress, setUserProgress] = useState<UserProgress>(() => {
     try {
-      const savedProgress = localStorage.getItem('linguaflow_progress');
+      const savedProgress = localStorage.getItem('palabrita_progress');
       if (savedProgress) {
         const parsed = JSON.parse(savedProgress);
         return {
@@ -54,7 +54,7 @@ const App: React.FC = () => {
     const loadWords = async () => {
       try {
         const masterWords = await getInitialWords();
-        const savedWordsJSON = localStorage.getItem('linguaflow_words');
+        const savedWordsJSON = localStorage.getItem('palabrita_words');
         const savedWords = savedWordsJSON ? JSON.parse(savedWordsJSON) : [];
 
         if (savedWords.length === 0) {
@@ -81,12 +81,12 @@ const App: React.FC = () => {
 
   useEffect(() => {
     if (!isLoading) {
-      localStorage.setItem('linguaflow_words', JSON.stringify(words));
+      localStorage.setItem('palabrita_words', JSON.stringify(words));
     }
   }, [words, isLoading]);
 
   useEffect(() => {
-    localStorage.setItem('linguaflow_progress', JSON.stringify({
+    localStorage.setItem('palabrita_progress', JSON.stringify({
       ...userProgress,
       lastSession: userProgress.lastSession.toISOString(),
       achievements: Array.from(userProgress.achievements), // Convert Set to array for JSON
@@ -137,9 +137,9 @@ const App: React.FC = () => {
     if (sessionWords.length > 0) {
         const todayKey = now.toISOString().split('T')[0]; // YYYY-MM-DD
         try {
-            const activityLog = JSON.parse(localStorage.getItem('linguaflow_activity') || '{}');
+            const activityLog = JSON.parse(localStorage.getItem('palabrita_activity') || '{}');
             activityLog[todayKey] = (activityLog[todayKey] || 0) + sessionWords.length;
-            localStorage.setItem('linguaflow_activity', JSON.stringify(activityLog));
+            localStorage.setItem('palabrita_activity', JSON.stringify(activityLog));
         } catch (e) {
             console.error("Failed to update activity log", e);
         }

--- a/components/Dashboard.tsx
+++ b/components/Dashboard.tsx
@@ -31,7 +31,7 @@ const Dashboard: React.FC<DashboardProps> = ({ userProgress, words, learningQueu
     const [weeklyActivity, setWeeklyActivity] = useState<{name: string, ord: number}[]>([]);
 
     useEffect(() => {
-        const activityLog = JSON.parse(localStorage.getItem('linguaflow_activity') || '{}');
+        const activityLog = JSON.parse(localStorage.getItem('palabrita_activity') || '{}');
         const activityData = [];
         const today = new Date();
         

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -21,7 +21,7 @@ const Header: React.FC<HeaderProps> = ({ userProgress }) => {
   return (
     <header className="p-4 border-b border-slate-200 bg-white/80 backdrop-blur-sm sticky top-0 z-10">
       <div className="flex justify-between items-center">
-        <h1 className="text-xl font-bold text-slate-900">LinguaFlow</h1>
+        <h1 className="text-xl font-bold text-slate-900">Palabrita</h1>
         <div className="flex items-center space-x-4">
             <StatItem icon={<Icon name="fire" />} value={userProgress.streak} label="Streak" />
             <StatItem icon={<Icon name="star" />} value={userProgress.points} label="Poäng" />

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>LinguaFlow - Spanska för Svenskar</title>
+    <title>Palabrita - Spanska för Svenskar</title>
     <link rel="manifest" href="/manifest.json" />
     <meta name="theme-color" content="#4f46e5" />
     <link rel="apple-touch-icon" href="/app-icon.png" />

--- a/manifest.json
+++ b/manifest.json
@@ -1,8 +1,8 @@
 {
-  "short_name": "LinguaFlow",
-  "name": "LinguaFlow - Spanska för Svenskar",
+  "short_name": "Palabrita",
+  "name": "Palabrita - Spanska för Svenskar",
   "description": "En modern och engagerande mobilapp för svensktalande att lära sig spanska.",
-  "start_url": "/lingua-flow/",
+  "start_url": "/palabrita/",
   "display": "standalone",
   "theme_color": "#4f46e5",
   "background_color": "#ffffff",

--- a/metadata.json
+++ b/metadata.json
@@ -1,5 +1,5 @@
 {
-  "name": "LinguaFlow - Spanska för Svenskar",
+  "name": "Palabrita - Spanska för Svenskar",
   "description": "En modern och engagerande mobilapp för svensktalande att lära sig spanska. Inspirerad av Stripes rena och intuitiva design, använder appen ett adaptivt system med bildkort för att hjälpa dig bemästra de 5000 vanligaste spanska orden genom gamification och spårad repetition.",
   "requestFramePermissions": []
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "linguaflow---spanska-för-svenskar",
+  "name": "palabrita---spanska-för-svenskar",
   "version": "0.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "linguaflow---spanska-för-svenskar",
+      "name": "palabrita---spanska-för-svenskar",
       "version": "0.0.0",
       "dependencies": {
         "react": "^19.1.1",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "linguaflow---spanska-för-svenskar",
+  "name": "palabrita---spanska-för-svenskar",
   "private": true,
   "version": "0.0.0",
   "type": "module",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -8,7 +8,7 @@ import manifest from './manifest.json';
 export default defineConfig(({ mode }) => {
     const env = loadEnv(mode, '.', '');
     return {
-      base: '/lingua-flow/',
+      base: '/palabrita/',
       server: {
         port: 3000,
         host: '0.0.0.0',


### PR DESCRIPTION
## Summary
- update UI strings and metadata to use the new Palabrita name
- align local storage keys, package metadata, and Vite PWA settings with the Palabrita slug

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d7cfbddca4832bb5e36f36c06d5cab