### PR TITLE
Hook settings into reminders and celebrations

### DIFF
--- a/components/Achievements.tsx
+++ b/components/Achievements.tsx
@@ -13,17 +13,17 @@ const Achievements: React.FC<AchievementsProps> = ({ data, userProgress }) => {
 
     return (
         <div>
-            <h2 className="text-2xl font-bold text-slate-800 text-center mb-6">Dina Troféer</h2>
+            <h2 className="text-2xl font-bold text-slate-800 dark:text-slate-100 text-center mb-6">Dina Troféer</h2>
             <div className="grid grid-cols-2 gap-4">
                 {data.map((achievement) => {
                     const isUnlocked = unlockedAchievements.has(achievement.id);
                     return (
                         <Card key={achievement.id} className={`p-4 text-center transition-opacity ${isUnlocked ? 'opacity-100' : 'opacity-40'}`}>
-                           <div className={`mx-auto w-16 h-16 rounded-full flex items-center justify-center text-3xl mb-3 ${isUnlocked ? 'bg-indigo-100 text-indigo-600' : 'bg-slate-100 text-slate-400'}`}>
+                           <div className={`mx-auto w-16 h-16 rounded-full flex items-center justify-center text-3xl mb-3 ${isUnlocked ? 'bg-indigo-100 text-indigo-600 dark:bg-indigo-500/20 dark:text-indigo-300' : 'bg-slate-100 text-slate-400 dark:bg-slate-800 dark:text-slate-500'}`}>
                                 {achievement.icon}
                            </div>
-                           <h3 className="font-semibold text-slate-800">{achievement.title}</h3>
-                           <p className="text-xs text-slate-500 mt-1">{achievement.description}</p>
+                           <h3 className="font-semibold text-slate-800 dark:text-slate-100">{achievement.title}</h3>
+                           <p className="text-xs text-slate-500 dark:text-slate-400 mt-1">{achievement.description}</p>
                         </Card>
                     );
                 })}

--- a/components/Confetti.tsx
+++ b/components/Confetti.tsx
@@ -1,0 +1,48 @@
+import React, { useMemo } from 'react';
+import type { CSSProperties } from 'react';
+
+interface ConfettiPiece {
+  left: number;
+  delay: number;
+  duration: number;
+  drift: number;
+  size: number;
+  color: string;
+}
+
+const COLORS = ['#6366f1', '#f59e0b', '#10b981', '#ec4899', '#3b82f6', '#f97316'];
+
+const Confetti: React.FC = () => {
+  const pieces = useMemo<ConfettiPiece[]>(() => {
+    return Array.from({ length: 120 }).map(() => ({
+      left: Math.random() * 100,
+      delay: Math.random() * 2,
+      duration: 3 + Math.random() * 2,
+      drift: (Math.random() - 0.5) * 200,
+      size: 6 + Math.random() * 8,
+      color: COLORS[Math.floor(Math.random() * COLORS.length)],
+    }));
+  }, []);
+
+  return (
+    <div className="pointer-events-none fixed inset-0 z-50 overflow-hidden">
+      {pieces.map((piece, index) => (
+        <span
+          key={index}
+          className="confetti-piece"
+          style={{
+            left: `${piece.left}%`,
+            backgroundColor: piece.color,
+            width: piece.size,
+            height: piece.size * 2,
+            animationDelay: `${piece.delay}s`,
+            animationDuration: `${piece.duration}s`,
+            '--confetti-drift': `${piece.drift}px`,
+          } as CSSProperties & { ['--confetti-drift']?: string }}
+        />
+      ))}
+    </div>
+  );
+};
+
+export default Confetti;

--- a/components/Flashcard.tsx
+++ b/components/Flashcard.tsx
@@ -35,35 +35,35 @@ const Flashcard: React.FC<FlashcardProps> = ({ word, onAnswer }) => {
         onClick={handleFlip}
       >
         {/* Front of card */}
-        <div className="absolute w-full h-full backface-hidden bg-white border border-slate-200 rounded-2xl shadow-lg flex flex-col justify-center items-center p-6 text-center cursor-pointer">
-            <p className="text-slate-500 mb-4">Spanska</p>
-            <h2 className="text-5xl font-bold text-slate-900">{word.spanish}</h2>
-            <div className="absolute bottom-6 text-slate-400 flex items-center space-x-2">
+        <div className="absolute w-full h-full backface-hidden bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-2xl shadow-lg flex flex-col justify-center items-center p-6 text-center cursor-pointer">
+            <p className="text-slate-500 dark:text-slate-400 mb-4">Spanska</p>
+            <h2 className="text-5xl font-bold text-slate-900 dark:text-slate-100">{word.spanish}</h2>
+            <div className="absolute bottom-6 text-slate-400 dark:text-slate-500 flex items-center space-x-2">
                 <Icon name="flip" />
                 <span>Klicka för att vända</span>
             </div>
         </div>
 
         {/* Back of card */}
-        <div className="absolute w-full h-full rotate-u-180 backface-hidden bg-indigo-50 border border-indigo-200 rounded-2xl shadow-lg flex flex-col justify-between p-6 text-center rotate-y-180">
+        <div className="absolute w-full h-full rotate-u-180 backface-hidden bg-indigo-50 dark:bg-indigo-500/10 border border-indigo-200 dark:border-indigo-500/40 rounded-2xl shadow-lg flex flex-col justify-between p-6 text-center rotate-y-180">
           <div>
             <div>
-              <p className="text-indigo-500 mb-2 font-semibold">Svenska</p>
-              <h3 className="text-4xl font-bold text-indigo-900">{word.swedish}</h3>
-              <p className="text-slate-600 mt-6 italic">"{word.exampleSentence}"</p>
+              <p className="text-indigo-500 dark:text-indigo-300 mb-2 font-semibold">Svenska</p>
+              <h3 className="text-4xl font-bold text-indigo-900 dark:text-indigo-200">{word.swedish}</h3>
+              <p className="text-slate-600 dark:text-slate-300 mt-6 italic">"{word.exampleSentence}"</p>
             </div>
             <div className="mt-6">
-              <p className="text-sm text-slate-500 mb-3">Hur bra kan du detta ord?</p>
+              <p className="text-sm text-slate-500 dark:text-slate-400 mb-3">Hur bra kan du detta ord?</p>
               <div className="flex justify-center space-x-3">
                 <button
                   onClick={(e) => { e.stopPropagation(); handleGrade(false); }}
-                  className="flex-1 py-3 px-4 bg-red-100 text-red-700 rounded-lg font-semibold hover:bg-red-200 transition-colors"
+                  className="flex-1 py-3 px-4 bg-red-100 dark:bg-red-500/20 text-red-700 dark:text-red-200 rounded-lg font-semibold hover:bg-red-200 dark:hover:bg-red-500/30 transition-colors"
                 >
                   Svårt
                 </button>
                 <button
                   onClick={(e) => { e.stopPropagation(); handleGrade(true); }}
-                  className="flex-1 py-3 px-4 bg-emerald-100 text-emerald-700 rounded-lg font-semibold hover:bg-emerald-200 transition-colors"
+                  className="flex-1 py-3 px-4 bg-emerald-100 dark:bg-emerald-500/20 text-emerald-700 dark:text-emerald-200 rounded-lg font-semibold hover:bg-emerald-200 dark:hover:bg-emerald-500/30 transition-colors"
                 >
                   Lätt
                 </button>

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -9,19 +9,19 @@ interface HeaderProps {
 
 const StatItem: React.FC<{ icon: React.ReactNode; value: number | string; label: string }> = ({ icon, value, label }) => (
     <div className="flex items-center space-x-2">
-        <div className="text-indigo-500">{icon}</div>
+        <div className="text-indigo-500 dark:text-indigo-300">{icon}</div>
         <div>
-            <div className="font-bold text-slate-800">{value}</div>
-            <div className="text-xs text-slate-500">{label}</div>
+            <div className="font-bold text-slate-800 dark:text-slate-100">{value}</div>
+            <div className="text-xs text-slate-500 dark:text-slate-400">{label}</div>
         </div>
     </div>
 );
 
 const Header: React.FC<HeaderProps> = ({ userProgress }) => {
   return (
-    <header className="p-4 border-b border-slate-200 bg-white/80 backdrop-blur-sm sticky top-0 z-10">
+    <header className="p-4 border-b border-slate-200 dark:border-slate-700 bg-white/80 dark:bg-slate-900/80 backdrop-blur-sm sticky top-0 z-10">
       <div className="flex justify-between items-center">
-        <h1 className="text-xl font-bold text-slate-900">Palabrita</h1>
+        <h1 className="text-xl font-bold text-slate-900 dark:text-slate-100">Palabrita</h1>
         <div className="flex items-center space-x-4">
             <StatItem icon={<Icon name="fire" />} value={userProgress.streak} label="Streak" />
             <StatItem icon={<Icon name="star" />} value={userProgress.points} label="Poäng" />

--- a/components/LearningSession.tsx
+++ b/components/LearningSession.tsx
@@ -41,8 +41,8 @@ const LearningSession: React.FC<LearningSessionProps> = ({ words, onSessionCompl
 
     return (
       <div className="flex flex-col items-center justify-center h-full text-center">
-        <h2 className="text-3xl font-bold text-slate-800">Bra jobbat!</h2>
-        <p className="text-slate-500 mt-2">Du klarade {correctCount} av {totalCount} ord.</p>
+        <h2 className="text-3xl font-bold text-slate-800 dark:text-slate-100">Bra jobbat!</h2>
+        <p className="text-slate-500 dark:text-slate-400 mt-2">Du klarade {correctCount} av {totalCount} ord.</p>
         <div className="w-full max-w-xs my-8">
             <ProgressBar progress={(correctCount / (totalCount || 1)) * 100} />
         </div>
@@ -56,8 +56,8 @@ const LearningSession: React.FC<LearningSessionProps> = ({ words, onSessionCompl
   if (!currentWord) {
       return (
         <div className="flex flex-col items-center justify-center h-full text-center">
-          <h2 className="text-2xl font-bold text-slate-800">Inga ord för idag!</h2>
-          <p className="text-slate-500 mt-2">Kom tillbaka imorgon för fler repetitioner.</p>
+          <h2 className="text-2xl font-bold text-slate-800 dark:text-slate-100">Inga ord för idag!</h2>
+          <p className="text-slate-500 dark:text-slate-400 mt-2">Kom tillbaka imorgon för fler repetitioner.</p>
         </div>
       );
   }

--- a/components/ReminderBanner.tsx
+++ b/components/ReminderBanner.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import Card from './common/Card';
+import Button from './common/Button';
+
+interface ReminderBannerProps {
+  hoursSinceLastSession: number;
+  onStartSession: () => void;
+  onDismiss: () => void;
+}
+
+const ReminderBanner: React.FC<ReminderBannerProps> = ({ hoursSinceLastSession, onStartSession, onDismiss }) => {
+  const days = Math.floor(hoursSinceLastSession / 24);
+  const hours = Math.round(hoursSinceLastSession % 24);
+
+  const message = days > 0
+    ? `Det var ${days} ${days === 1 ? 'dag' : 'dagar'} sedan du senast repeterade.`
+    : `Det var ${hours} tim${hours === 1 ? 'me' : 'mar'} sedan du övade sist.`;
+
+  return (
+    <Card>
+      <div className="p-4 sm:p-5 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
+        <div>
+          <h3 className="text-sm font-semibold uppercase tracking-wide text-indigo-600 dark:text-indigo-300">Dags att repetera</h3>
+          <p className="mt-1 text-sm text-slate-600 dark:text-slate-300">{message} Ska vi ta några ord nu?</p>
+        </div>
+        <div className="flex items-center gap-3 self-end sm:self-auto">
+          <button
+            type="button"
+            onClick={onDismiss}
+            className="text-sm text-slate-500 hover:text-slate-700 dark:text-slate-400 dark:hover:text-slate-200"
+          >
+            Kanske senare
+          </button>
+          <Button onClick={onStartSession}>
+            Starta lektion
+          </Button>
+        </div>
+      </div>
+    </Card>
+  );
+};
+
+export default ReminderBanner;

--- a/components/Settings.tsx
+++ b/components/Settings.tsx
@@ -1,0 +1,124 @@
+import React from 'react';
+import Card from './common/Card';
+import type { AppSettings, ThemePreference } from '../types';
+
+interface SettingsProps {
+  settings: AppSettings;
+  onThemeChange: (preference: ThemePreference) => void;
+  onToggleReminders: (enabled: boolean) => void;
+  onToggleConfetti: (enabled: boolean) => void;
+  onDailyGoalChange: (goal: number) => void;
+}
+
+const themeOptions: { label: string; value: ThemePreference; description: string }[] = [
+  { label: 'System', value: 'system', description: 'Följer automatiskt systemets ljusa eller mörka läge.' },
+  { label: 'Ljust', value: 'light', description: 'Alltid ljust läge oavsett systeminställning.' },
+  { label: 'Mörkt', value: 'dark', description: 'Alltid mörkt läge oavsett systeminställning.' },
+];
+
+const Settings: React.FC<SettingsProps> = ({
+  settings,
+  onThemeChange,
+  onToggleReminders,
+  onToggleConfetti,
+  onDailyGoalChange,
+}) => {
+  return (
+    <div className="space-y-6">
+      <Card>
+        <div className="p-6 space-y-4">
+          <h2 className="text-lg font-semibold text-slate-800 dark:text-slate-100">Utseende</h2>
+          <p className="text-sm text-slate-500 dark:text-slate-400">
+            Välj hur Palabrita ska följa systemets mörkerläge eller använda ett eget.
+          </p>
+          <div className="grid gap-3 sm:grid-cols-3">
+            {themeOptions.map((option) => {
+              const isActive = settings.themePreference === option.value;
+              return (
+                <button
+                  key={option.value}
+                  type="button"
+                  onClick={() => onThemeChange(option.value)}
+                  className={`text-left p-3 rounded-xl border transition-colors focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 dark:focus:ring-offset-slate-900 ${
+                    isActive
+                      ? 'border-indigo-500 bg-indigo-50 text-indigo-700 dark:bg-indigo-500/10 dark:border-indigo-400'
+                      : 'border-slate-200 hover:border-indigo-300 hover:bg-indigo-50/40 dark:border-slate-700 dark:hover:border-indigo-500/80 dark:hover:bg-indigo-500/5'
+                  }`}
+                >
+                  <div className="font-semibold">{option.label}</div>
+                  <p className="text-xs mt-1 text-slate-500 dark:text-slate-400">{option.description}</p>
+                </button>
+              );
+            })}
+          </div>
+        </div>
+      </Card>
+
+      <Card>
+        <div className="p-6 space-y-4">
+          <h2 className="text-lg font-semibold text-slate-800 dark:text-slate-100">Studieplan</h2>
+          <div>
+            <div className="flex items-center justify-between">
+              <label htmlFor="daily-goal" className="text-sm font-medium text-slate-700 dark:text-slate-200">
+                Dagligt mål
+              </label>
+              <span className="text-sm text-slate-500 dark:text-slate-400">{settings.dailyGoal} ord</span>
+            </div>
+            <input
+              id="daily-goal"
+              type="range"
+              min={5}
+              max={50}
+              step={5}
+              value={settings.dailyGoal}
+              onChange={(event) => onDailyGoalChange(Number(event.target.value))}
+              className="w-full mt-3 accent-indigo-600"
+            />
+            <p className="text-xs text-slate-500 dark:text-slate-400 mt-1">
+              Hur många ord vill du repetera varje dag?
+            </p>
+          </div>
+        </div>
+      </Card>
+
+      <Card>
+        <div className="p-6 space-y-4">
+          <h2 className="text-lg font-semibold text-slate-800 dark:text-slate-100">Motivation</h2>
+          <div className="space-y-3">
+            <label className="flex items-center justify-between">
+              <div>
+                <p className="font-medium text-slate-800 dark:text-slate-100">Påminnelser</p>
+                <p className="text-xs text-slate-500 dark:text-slate-400">
+                  Få en vänlig knuff om du inte studerat på ett tag.
+                </p>
+              </div>
+              <input
+                type="checkbox"
+                checked={settings.remindersEnabled}
+                onChange={(event) => onToggleReminders(event.target.checked)}
+                className="h-5 w-5 rounded border-slate-300 text-indigo-600 focus:ring-indigo-500"
+              />
+            </label>
+
+            <label className="flex items-center justify-between">
+              <div>
+                <p className="font-medium text-slate-800 dark:text-slate-100">Fira framgångar</p>
+                <p className="text-xs text-slate-500 dark:text-slate-400">
+                  Visa animationer när du klarar en lektion perfekt.
+                </p>
+              </div>
+              <input
+                type="checkbox"
+                checked={settings.enableConfetti}
+                onChange={(event) => onToggleConfetti(event.target.checked)}
+                className="h-5 w-5 rounded border-slate-300 text-indigo-600 focus:ring-indigo-500"
+              />
+            </label>
+          </div>
+        </div>
+      </Card>
+    </div>
+  );
+};
+
+export default Settings;

--- a/components/UpdateNotification.tsx
+++ b/components/UpdateNotification.tsx
@@ -6,11 +6,11 @@ interface UpdateNotificationProps {
 
 const UpdateNotification: React.FC<UpdateNotificationProps> = ({ onUpdate }) => {
   return (
-    <div className="fixed bottom-20 right-4 bg-white shadow-lg rounded-lg p-4 flex items-center space-x-4 z-50">
-      <p className="text-slate-700">En ny version finns tillgänglig.</p>
+    <div className="fixed bottom-20 right-4 bg-white dark:bg-slate-900 shadow-lg dark:shadow-black/30 rounded-lg p-4 flex items-center space-x-4 z-50">
+      <p className="text-slate-700 dark:text-slate-200">En ny version finns tillgänglig.</p>
       <button
         onClick={onUpdate}
-        className="bg-indigo-600 text-white px-4 py-2 rounded-lg hover:bg-indigo-700 transition-colors"
+        className="bg-indigo-600 dark:bg-indigo-500 text-white px-4 py-2 rounded-lg hover:bg-indigo-700 dark:hover:bg-indigo-400 transition-colors"
       >
         Ladda om
       </button>

--- a/components/common/Button.tsx
+++ b/components/common/Button.tsx
@@ -9,11 +9,11 @@ const Button: React.FC<ButtonProps> = ({ children, className = '', ...props }) =
   return (
     <button
       className={`
-        w-full bg-indigo-600 text-white font-semibold py-3 px-6 rounded-lg 
-        shadow-sm hover:bg-indigo-700 
-        focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 
+        w-full bg-indigo-600 dark:bg-indigo-500 text-white font-semibold py-3 px-6 rounded-lg
+        shadow-sm hover:bg-indigo-700 dark:hover:bg-indigo-400
+        focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 dark:focus:ring-offset-slate-900
         transition-all duration-200 ease-in-out transform active:scale-95
-        disabled:bg-slate-300 disabled:cursor-not-allowed disabled:shadow-none disabled:scale-100
+        disabled:bg-slate-300 dark:disabled:bg-slate-700 disabled:cursor-not-allowed disabled:shadow-none disabled:scale-100
         ${className}
       `}
       {...props}

--- a/components/common/Card.tsx
+++ b/components/common/Card.tsx
@@ -8,7 +8,7 @@ interface CardProps {
 
 const Card: React.FC<CardProps> = ({ children, className = '' }) => {
   return (
-    <div className={`bg-white border border-slate-200 rounded-xl shadow-sm ${className}`}>
+    <div className={`bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-xl shadow-sm dark:shadow-none ${className}`}>
       {children}
     </div>
   );

--- a/components/common/ProgressBar.tsx
+++ b/components/common/ProgressBar.tsx
@@ -7,9 +7,9 @@ interface ProgressBarProps {
 
 const ProgressBar: React.FC<ProgressBarProps> = ({ progress }) => {
   return (
-    <div className="w-full bg-slate-200 rounded-full h-2.5">
-      <div 
-        className="bg-indigo-600 h-2.5 rounded-full transition-all duration-500 ease-out" 
+    <div className="w-full bg-slate-200 dark:bg-slate-800 rounded-full h-2.5">
+      <div
+        className="bg-indigo-600 dark:bg-indigo-500 h-2.5 rounded-full transition-all duration-500 ease-out"
         style={{ width: `${progress}%` }}
       ></div>
     </div>

--- a/index.css
+++ b/index.css
@@ -1,1 +1,37 @@
 @import "tailwindcss";
+
+@layer base {
+  html,
+  body,
+  #root {
+    height: 100%;
+  }
+
+  body {
+    @apply bg-slate-50 text-slate-800 transition-colors duration-300 ease-in-out;
+  }
+
+  .dark body {
+    @apply bg-slate-950 text-slate-100;
+  }
+}
+
+@keyframes confetti-fall {
+  0% {
+    transform: translate3d(0, -100%, 0) rotateZ(0deg);
+    opacity: 1;
+  }
+  100% {
+    transform: translate3d(var(--confetti-drift, 0px), 110vh, 0) rotateZ(360deg);
+    opacity: 0;
+  }
+}
+
+.confetti-piece {
+  position: absolute;
+  top: -10vh;
+  border-radius: 9999px;
+  animation-name: confetti-fall;
+  animation-timing-function: linear;
+  animation-iteration-count: infinite;
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,5 +1,6 @@
 /** @type {import('tailwindcss').Config} */
 export default {
+  darkMode: 'class',
   content: [
     "./index.html",
     "./{,src/**/}*.{js,ts,jsx,tsx}",

--- a/types.ts
+++ b/types.ts
@@ -31,6 +31,16 @@ export enum View {
   Dashboard = 'Översikt',
   Learning = 'Lektion',
   Achievements = 'Trofér',
+  Settings = 'Inställningar',
+}
+
+export type ThemePreference = 'system' | 'light' | 'dark';
+
+export interface AppSettings {
+  themePreference: ThemePreference;
+  remindersEnabled: boolean;
+  enableConfetti: boolean;
+  dailyGoal: number;
 }
 
 export interface Achievement {


### PR DESCRIPTION
## Summary
- add reminder evaluation logic that respects the reminders toggle and shows an in-app banner plus optional browser notifications
- celebrate perfect sessions with a configurable confetti overlay and supporting styles
- add dedicated components for the reminder banner and confetti animation

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d7d9205368832b880fe5d630a26066