### PR TITLE
Refine translation tooling with interactive fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
     "build": "vite build",
     "preview": "vite preview",
     "predeploy": "npm run build",
-    "deploy": "gh-pages -d dist"
+    "deploy": "gh-pages -d dist",
+    "fill:words": "node scripts/fill_spanish_words.mjs",
+    "verify:words": "node scripts/verify_spanish_words.mjs"
   },
   "dependencies": {
     "react": "^19.1.1",

--- a/scripts/fill_spanish_words.mjs
+++ b/scripts/fill_spanish_words.mjs
@@ -1,0 +1,144 @@
+import { createReadStream } from 'node:fs';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import readline from 'node:readline';
+import { fileURLToPath } from 'node:url';
+
+import { requestJsonResponse } from './lib/openai_client.mjs';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const WORD_LIST_PATH = path.resolve(__dirname, '..', 'data', 'common_spanish_words_50k.txt');
+const OUTPUT_PATH = path.resolve(__dirname, '..', 'data', 'spanish_words.json');
+
+const LIMIT = (() => {
+  const limitFlag = process.argv.find(arg => arg.startsWith('--limit='));
+  if (!limitFlag) return null;
+  const parsed = Number.parseInt(limitFlag.split('=')[1], 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : null;
+})();
+
+const GENERATION_SCHEMA = {
+  name: 'SpanishSwedishEntry',
+  schema: {
+    type: 'object',
+    required: ['translation', 'sentence_es', 'sentence_sv'],
+    properties: {
+      translation: {
+        type: 'string',
+        description: 'Swedish translation(s) for the lemma. Prefer comma-separated alternatives when needed.',
+      },
+      sentence_es: {
+        type: 'string',
+        description: 'Natural Spanish sentence that includes the exact lemma with correct accents.',
+      },
+      sentence_sv: {
+        type: 'string',
+        description: 'Accurate Swedish translation of the provided Spanish sentence.',
+      },
+    },
+  },
+};
+
+const existingEntries = await readExistingEntries();
+const existingWordSet = new Set(existingEntries.map(entry => entry.word));
+
+const reader = readline.createInterface({
+  input: createReadStream(WORD_LIST_PATH, { encoding: 'utf8' }),
+  crlfDelay: Infinity,
+});
+
+let addedCount = 0;
+for await (const line of reader) {
+  const [rawWord] = line.trim().split(/\s+/);
+  if (!rawWord) continue;
+
+  const word = rawWord.normalize('NFC');
+  if (existingWordSet.has(word)) {
+    continue;
+  }
+
+  const generated = await generateEntry(word);
+  const entry = {
+    word,
+    translation: cleanOneLine(generated.translation),
+    sentence_es: cleanOneLine(generated.sentence_es),
+    sentence_sv: cleanOneLine(generated.sentence_sv),
+  };
+
+  existingEntries.push(entry);
+  existingWordSet.add(word);
+
+  await writeEntries(existingEntries);
+  addedCount += 1;
+  console.log(`Added entry for "${word}" (${addedCount} new total).`);
+
+  if (LIMIT && addedCount >= LIMIT) {
+    break;
+  }
+}
+
+if (addedCount === 0) {
+  console.log('No new words were added.');
+} else {
+  console.log(`Finished processing. Added ${addedCount} word${addedCount === 1 ? '' : 's'}.`);
+}
+
+async function generateEntry(word) {
+  const result = await requestJsonResponse({
+    messages: [
+      {
+        role: 'system',
+        content: 'You are an expert bilingual lexicographer. Produce accurate Swedish equivalents for Spanish lemmas. Respect accents and diacritics in both languages.',
+      },
+      {
+        role: 'user',
+        content: [
+          'For the given Spanish lemma, provide a trustworthy Swedish translation and paired example sentences.',
+          '',
+          'Requirements:',
+          '- Pay heightened attention to Spanish accent marks—never replace accented vowels with their unaccented counterparts.',
+          '- Return well-formed Spanish and Swedish sentences that are literal translations of each other.',
+          '- The Spanish sentence must contain the lemma exactly as provided (including accents).',
+          '- Keep responses concise (max ~25 words per sentence).',
+          '- Output must be valid UTF-8.',
+          '',
+          `Spanish lemma: ${word}`,
+        ].join('\n'),
+      },
+    ],
+    schema: GENERATION_SCHEMA,
+    temperature: 0.1,
+    maxOutputTokens: 600,
+  });
+
+  return result;
+}
+
+async function readExistingEntries() {
+  try {
+    const raw = await fs.readFile(OUTPUT_PATH, 'utf8');
+    const parsed = JSON.parse(raw);
+    if (Array.isArray(parsed)) {
+      return parsed;
+    }
+    console.warn('Unexpected JSON structure in spanish_words.json. Starting with an empty array.');
+    return [];
+  } catch (error) {
+    if (error.code === 'ENOENT') {
+      console.log('No existing spanish_words.json found. Starting from scratch.');
+      return [];
+    }
+    throw error;
+  }
+}
+
+async function writeEntries(entries) {
+  const data = JSON.stringify(entries, null, 2);
+  await fs.writeFile(OUTPUT_PATH, `${data}\n`, 'utf8');
+}
+
+function cleanOneLine(text) {
+  return text.replace(/\s+/g, ' ').trim();
+}

--- a/scripts/lib/openai_client.mjs
+++ b/scripts/lib/openai_client.mjs
@@ -1,0 +1,77 @@
+import assert from 'node:assert';
+
+const DEFAULT_MODEL = process.env.OPENAI_MODEL ?? 'gpt-4.1-mini';
+const API_KEY = process.env.OPENAI_API_KEY;
+const API_URL = process.env.OPENAI_API_URL ?? 'https://api.openai.com/v1/responses';
+
+if (!API_KEY) {
+  throw new Error('OPENAI_API_KEY environment variable is required to call the OpenAI API.');
+}
+
+export async function requestJsonResponse({ messages, schema, temperature = 0.2, maxOutputTokens = 400 }) {
+  assert(Array.isArray(messages) && messages.length > 0, 'messages array is required');
+  assert(schema && typeof schema === 'object', 'schema definition is required');
+
+  const response = await fetch(API_URL, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${API_KEY}`,
+    },
+    body: JSON.stringify({
+      model: DEFAULT_MODEL,
+      input: messages,
+      temperature,
+      max_output_tokens: maxOutputTokens,
+      response_format: {
+        type: 'json_schema',
+        json_schema: {
+          name: schema.name,
+          strict: true,
+          schema: {
+            additionalProperties: false,
+            ...schema.schema,
+          },
+        },
+      },
+    }),
+  });
+
+  if (!response.ok) {
+    const errorText = await safeReadText(response);
+    throw new Error(`OpenAI API request failed with status ${response.status}: ${errorText}`);
+  }
+
+  const payload = await response.json();
+  const text = extractTextFromResponse(payload);
+
+  try {
+    return JSON.parse(text);
+  } catch (error) {
+    throw new Error(`Failed to parse OpenAI response as JSON: ${error.message}\nRaw response: ${text}`);
+  }
+}
+
+async function safeReadText(response) {
+  try {
+    return await response.text();
+  } catch (error) {
+    return `<failed to read body: ${error.message}>`;
+  }
+}
+
+function extractTextFromResponse(payload) {
+  if (typeof payload?.output_text === 'string' && payload.output_text.trim()) {
+    return payload.output_text.trim();
+  }
+
+  const text = payload?.output?.flatMap(item => item?.content ?? [])
+    .map(content => (typeof content?.text === 'string' ? content.text : null))
+    .find(Boolean);
+
+  if (text) {
+    return text.trim();
+  }
+
+  throw new Error('Unexpected OpenAI response payload format.');
+}

--- a/scripts/verify_spanish_words.mjs
+++ b/scripts/verify_spanish_words.mjs
@@ -1,0 +1,263 @@
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import { stdin as input, stdout as output } from 'node:process';
+import readline from 'node:readline/promises';
+import { fileURLToPath } from 'node:url';
+
+import { requestJsonResponse } from './lib/openai_client.mjs';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const WORD_DATA_PATH = path.resolve(__dirname, '..', 'data', 'spanish_words.json');
+const PROGRESS_PATH = path.resolve(__dirname, '..', 'data', 'verification_progress.json');
+const ISSUES_PATH = path.resolve(__dirname, '..', 'data', 'verification_issues.json');
+
+const RATE_LIMIT_DELAY_MS = Number(process.env.OPENAI_REQUEST_DELAY_MS ?? 0);
+
+const VERIFICATION_SCHEMA = {
+  name: 'SpanishSwedishVerification',
+  schema: {
+    type: 'object',
+    required: [
+      'translation_correct',
+      'sentence_correct',
+      'translation_feedback',
+      'sentence_feedback',
+      'severity',
+    ],
+    properties: {
+      translation_correct: { type: 'boolean' },
+      sentence_correct: { type: 'boolean' },
+      severity: { type: 'string', enum: ['ok', 'minor', 'major'] },
+      translation_feedback: { type: 'string' },
+      sentence_feedback: { type: 'string' },
+      suggested_translation: { type: ['string', 'null'], description: 'Suggested Swedish translation if corrections are needed.' },
+      suggested_sentence_sv: { type: ['string', 'null'], description: 'Suggested Swedish sentence aligned with the Spanish sentence.' },
+      notes: { type: ['string', 'null'] },
+    },
+  },
+};
+
+const entries = await readEntries();
+
+if (entries.length === 0) {
+  console.log('No entries found in spanish_words.json. Nothing to verify.');
+  process.exit(0);
+}
+
+const rl = readline.createInterface({ input, output });
+
+const startIndex = await readProgress();
+
+console.log(`Verifying ${entries.length - startIndex} entries (starting at index ${startIndex}).`);
+
+const issues = [];
+
+for (let index = startIndex; index < entries.length; index += 1) {
+  const entry = entries[index];
+  console.log(`Checking "${entry.word}" (#${index + 1}/${entries.length})...`);
+
+  try {
+    const analysis = await analyzeEntry(entry);
+
+    let translationFixed = false;
+
+    if (!analysis.translation_correct) {
+      console.warn(`  Translation flagged: ${analysis.translation_feedback}`);
+      translationFixed = await promptTranslationResolution(entry, analysis);
+
+      if (!translationFixed) {
+        issues.push({
+          type: 'translation',
+          index,
+          word: entry.word,
+          translation: entry.translation,
+          feedback: analysis.translation_feedback,
+          suggested_translation: analysis.suggested_translation,
+          severity: analysis.severity,
+        });
+      }
+    }
+
+    if (!analysis.sentence_correct) {
+      issues.push({
+        type: 'sentence',
+        index,
+        word: entry.word,
+        spanish_sentence: entry.sentence_es,
+        swedish_sentence: entry.sentence_sv,
+        feedback: analysis.sentence_feedback,
+        suggested_sentence_sv: analysis.suggested_sentence_sv,
+        severity: analysis.severity,
+      });
+      console.warn(`  Sentence flagged: ${analysis.sentence_feedback}`);
+    }
+
+    if ((analysis.translation_correct || translationFixed) && analysis.sentence_correct) {
+      console.log('  Entry looks good.');
+    }
+
+    if (analysis.notes) {
+      console.log(`  Notes: ${analysis.notes}`);
+    }
+  } catch (error) {
+    issues.push({
+      type: 'verification-error',
+      index,
+      word: entry.word,
+      message: error.message,
+    });
+    console.error(`  Error verifying "${entry.word}": ${error.message}`);
+  }
+
+  await writeProgress(index + 1);
+
+  if (RATE_LIMIT_DELAY_MS > 0) {
+    await delay(RATE_LIMIT_DELAY_MS);
+  }
+}
+
+await rl.close();
+
+if (issues.length > 0) {
+  console.log(`Verification completed with ${issues.length} potential issue(s). Details saved to verification_issues.json.`);
+  await fs.writeFile(ISSUES_PATH, `${JSON.stringify(issues, null, 2)}\n`, 'utf8');
+} else {
+  console.log('Verification completed. No issues detected.');
+  try {
+    await fs.unlink(ISSUES_PATH);
+  } catch (error) {
+    if (error.code !== 'ENOENT') {
+      throw error;
+    }
+  }
+}
+
+async function analyzeEntry(entry) {
+  const result = await requestJsonResponse({
+    messages: [
+      {
+        role: 'system',
+        content: 'You are a meticulous bilingual quality editor who validates Spanish to Swedish translations. Focus on semantic accuracy, tone, and correct diacritics.',
+      },
+      {
+        role: 'user',
+        content: [
+          'Evaluate whether the recorded Swedish translation and example sentences accurately reflect the Spanish source.',
+          '',
+          'Spanish lemma:',
+          entry.word,
+          '',
+          'Recorded Swedish translation(s):',
+          entry.translation,
+          '',
+          'Spanish sentence:',
+          entry.sentence_es,
+          '',
+          'Swedish sentence:',
+          entry.sentence_sv,
+          '',
+          'Rules:',
+          '- Pay close attention to Spanish accents (e.g., "té" vs "te").',
+          '- Confirm that the Swedish sentence is a faithful translation of the Spanish sentence.',
+          '- If anything is off, explain why and provide a suggested correction.',
+          '- Classify severity as "ok" when both checks pass, "minor" when small corrections are needed, and "major" for significant mistakes.',
+          '- If everything looks correct, mark both checks as true, use severity "ok", and keep feedback brief.',
+        ].join('\n'),
+      },
+    ],
+    schema: VERIFICATION_SCHEMA,
+    temperature: 0,
+    maxOutputTokens: 800,
+  });
+
+  return {
+    translation_correct: result.translation_correct,
+    sentence_correct: result.sentence_correct,
+    severity: result.severity,
+    translation_feedback: result.translation_feedback.trim(),
+    sentence_feedback: result.sentence_feedback.trim(),
+    suggested_translation: result.suggested_translation ?? null,
+    suggested_sentence_sv: result.suggested_sentence_sv ?? null,
+    notes: result.notes ?? null,
+  };
+}
+
+async function readEntries() {
+  const raw = await fs.readFile(WORD_DATA_PATH, 'utf8');
+  const parsed = JSON.parse(raw);
+  if (!Array.isArray(parsed)) {
+    throw new Error('Expected spanish_words.json to contain an array.');
+  }
+  return parsed;
+}
+
+async function readProgress() {
+  try {
+    const raw = await fs.readFile(PROGRESS_PATH, 'utf8');
+    const parsed = JSON.parse(raw);
+    if (typeof parsed?.index === 'number' && parsed.index >= 0) {
+      return Math.min(parsed.index, entries.length);
+    }
+    console.warn('Invalid progress file detected. Restarting verification from the beginning.');
+    return 0;
+  } catch (error) {
+    if (error.code === 'ENOENT') {
+      return 0;
+    }
+    throw error;
+  }
+}
+
+async function writeProgress(index) {
+  const payload = { index, updatedAt: new Date().toISOString() };
+  await fs.writeFile(PROGRESS_PATH, `${JSON.stringify(payload, null, 2)}\n`, 'utf8');
+}
+
+async function writeEntries(entriesToPersist) {
+  const payload = JSON.stringify(entriesToPersist, null, 2);
+  await fs.writeFile(WORD_DATA_PATH, `${payload}\n`, 'utf8');
+}
+
+function delay(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+async function promptTranslationResolution(entry, analysis) {
+  console.log(`  Current translation: ${entry.translation}`);
+  if (analysis.suggested_translation) {
+    console.log(`  Suggested translation: ${analysis.suggested_translation}`);
+  }
+  console.log(`  Feedback: ${analysis.translation_feedback}`);
+
+  const hasSuggestion = Boolean(analysis.suggested_translation?.trim());
+  const promptText = hasSuggestion
+    ? '    Apply the suggested translation? (y/N): '
+    : '    Provide a corrected translation now? (y/N): ';
+
+  const accept = await promptYesNo(promptText);
+  if (!accept) {
+    return false;
+  }
+
+  let nextTranslation = analysis.suggested_translation?.trim();
+  if (!nextTranslation) {
+    const manual = (await rl.question('    Enter the corrected Swedish translation: ')).trim();
+    if (!manual) {
+      console.log('    No translation entered. Skipping automatic fix.');
+      return false;
+    }
+    nextTranslation = manual;
+  }
+
+  entry.translation = nextTranslation;
+  await writeEntries(entries);
+  console.log('    Updated translation saved to spanish_words.json.');
+  return true;
+}
+
+async function promptYesNo(promptText) {
+  const answer = (await rl.question(promptText)).trim().toLowerCase();
+  return answer === 'y' || answer === 'yes';
+}


### PR DESCRIPTION
## Summary
- remind the GPT-4.1 population script to double-check Spanish accent marks when generating data
- extend the verifier to prompt for accepting or entering corrections when a translation is flagged
- persist accepted fixes directly back to the dataset while maintaining resumable progress tracking

## Testing
- not run (requires OpenAI API access and interactive confirmation)

------
https://chatgpt.com/codex/tasks/task_e_68d7d4207544832b94e9a23fca9dbc2d