### PR TITLE
Fix initial last session timestamp for new users

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -130,9 +130,12 @@ const App: React.FC = () => {
       const savedProgress = localStorage.getItem('palabrita_progress');
       if (savedProgress) {
         const parsed = JSON.parse(savedProgress);
+        const parsedLastSession = parsed.lastSession ? new Date(parsed.lastSession) : new Date();
+        const lastSession = Number.isNaN(parsedLastSession.getTime()) ? new Date() : parsedLastSession;
+
         return {
           ...parsed,
-          lastSession: new Date(parsed.lastSession),
+          lastSession,
           achievements: new Set(parsed.achievements || []), // Convert stored array back to a Set
         };
       }
@@ -143,7 +146,7 @@ const App: React.FC = () => {
       points: 0,
       level: 1,
       streak: 0,
-      lastSession: new Date(0),
+      lastSession: new Date(),
       achievements: new Set(),
     };
   });


### PR DESCRIPTION
## Summary
- ensure the stored last session date falls back to the current time when missing or invalid
- default new users to a current last session timestamp to avoid exaggerated reminder copy

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d80a925478832b949adc06b4cee51f