### PR TITLE
Improve light mode styling and theme selector layout

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -464,8 +464,8 @@ const App: React.FC = () => {
 
   if (isLoading) {
     return (
-        <div className="bg-slate-50 dark:bg-slate-950 min-h-screen flex items-center justify-center text-slate-800 dark:text-slate-200">
-            <div className="max-w-md mx-auto w-full h-screen bg-white dark:bg-slate-900 shadow-2xl shadow-slate-300 dark:shadow-black/40 flex flex-col items-center justify-center">
+        <div className="bg-white dark:bg-slate-950 min-h-screen flex items-center justify-center text-slate-800 dark:text-slate-200">
+            <div className="max-w-md mx-auto w-full h-screen bg-white dark:bg-slate-900 shadow-2xl shadow-slate-300/70 dark:shadow-black/40 flex flex-col items-center justify-center">
                 <div className="text-xl font-semibold text-slate-600 dark:text-slate-200">Laddar ord...</div>
             </div>
         </div>
@@ -502,8 +502,8 @@ const App: React.FC = () => {
   };
 
     return (
-      <div className="bg-slate-50 dark:bg-slate-950 min-h-screen text-slate-800 dark:text-slate-100" data-theme={resolvedTheme}>
-        <div className="max-w-md mx-auto bg-white dark:bg-slate-900 min-h-screen shadow-2xl shadow-slate-300 dark:shadow-black/40 flex flex-col">
+      <div className="bg-white dark:bg-slate-950 min-h-screen text-slate-800 dark:text-slate-100" data-theme={resolvedTheme}>
+        <div className="max-w-md mx-auto bg-white dark:bg-slate-900 min-h-screen shadow-2xl shadow-slate-300/70 dark:shadow-black/40 flex flex-col">
           <Header userProgress={userProgress} />
           {showCelebration && settings.enableConfetti && <Confetti />}
           <main className="flex-grow p-4 sm:p-6 overflow-y-auto pb-20 space-y-4">

--- a/components/Settings.tsx
+++ b/components/Settings.tsx
@@ -31,7 +31,7 @@ const Settings: React.FC<SettingsProps> = ({
           <p className="text-sm text-slate-500 dark:text-slate-400">
             Välj hur Palabrita ska följa systemets mörkerläge eller använda ett eget.
           </p>
-          <div className="grid gap-3 sm:grid-cols-3">
+          <div className="flex flex-col gap-3 sm:flex-row">
             {themeOptions.map((option) => {
               const isActive = settings.themePreference === option.value;
               return (
@@ -39,10 +39,10 @@ const Settings: React.FC<SettingsProps> = ({
                   key={option.value}
                   type="button"
                   onClick={() => onThemeChange(option.value)}
-                  className={`text-left p-3 rounded-xl border transition-colors focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 dark:focus:ring-offset-slate-900 ${
+                  className={`flex-1 text-left p-4 rounded-2xl border transition-colors focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 dark:focus:ring-offset-slate-900 ${
                     isActive
-                      ? 'border-indigo-500 bg-indigo-50 text-indigo-700 dark:bg-indigo-500/10 dark:border-indigo-400'
-                      : 'border-slate-200 hover:border-indigo-300 hover:bg-indigo-50/40 dark:border-slate-700 dark:hover:border-indigo-500/80 dark:hover:bg-indigo-500/5'
+                      ? 'border-indigo-500 bg-indigo-50 text-indigo-700 shadow-sm dark:bg-indigo-500/10 dark:border-indigo-400'
+                      : 'border-slate-200 bg-white hover:border-indigo-300 hover:bg-indigo-50/40 dark:border-slate-700 dark:bg-transparent dark:hover:border-indigo-500/80 dark:hover:bg-indigo-500/5'
                   }`}
                 >
                   <div className="font-semibold">{option.label}</div>

--- a/index.css
+++ b/index.css
@@ -8,7 +8,7 @@
   }
 
   body {
-    @apply bg-slate-50 text-slate-800 transition-colors duration-300 ease-in-out;
+    @apply bg-white text-slate-800 transition-colors duration-300 ease-in-out;
   }
 
   .dark body {


### PR DESCRIPTION
## Summary
- set the body and shell backgrounds to pure white so light mode looks distinct from dark mode
- adjust shell shadows to stay soft in light mode while keeping dark mode styles intact
- rework the theme selection buttons into a flexible row layout that fits smaller screens

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d80ae60718832b92c531861aa6ece0