### PR TITLE
Ensure dark utilities respect explicit theme overrides

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -53,18 +53,23 @@ const App: React.FC = () => {
         if (typeof document !== 'undefined') {
           document.documentElement.classList.add('dark');
           document.documentElement.style.colorScheme = 'dark';
+          document.documentElement.setAttribute('data-color-scheme', 'dark');
         }
         return 'dark';
       }
       if (typeof document !== 'undefined') {
         document.documentElement.classList.remove('dark');
         document.documentElement.style.colorScheme = 'light';
+        document.documentElement.setAttribute('data-color-scheme', 'light');
       }
       return 'light';
     }
     if (typeof document !== 'undefined') {
-      document.documentElement.classList.toggle('dark', initialSettings.themePreference === 'dark');
-      document.documentElement.style.colorScheme = initialSettings.themePreference;
+      const isDark = initialSettings.themePreference === 'dark';
+      const nextTheme = isDark ? 'dark' : 'light';
+      document.documentElement.classList.toggle('dark', isDark);
+      document.documentElement.style.colorScheme = nextTheme;
+      document.documentElement.setAttribute('data-color-scheme', nextTheme);
     }
     return initialSettings.themePreference;
   });
@@ -106,6 +111,7 @@ const App: React.FC = () => {
       setResolvedTheme(nextTheme);
       document.documentElement.classList.toggle('dark', nextTheme === 'dark');
       document.documentElement.style.colorScheme = nextTheme;
+      document.documentElement.setAttribute('data-color-scheme', nextTheme);
     };
 
     applyTheme(mediaQuery.matches);

--- a/index.css
+++ b/index.css
@@ -1,6 +1,16 @@
 @import "tailwindcss";
 
+@custom-variant dark (&:is(.dark *, html[data-color-scheme='dark'] *));
+
 @layer base {
+  html {
+    color-scheme: light;
+  }
+
+  html[data-color-scheme='dark'] {
+    color-scheme: dark;
+  }
+
   html,
   body,
   #root {


### PR DESCRIPTION
## Summary
- override Tailwind's dark variant to target the `.dark` class and `html[data-color-scheme="dark"]`
- prevent prefers-color-scheme media queries from forcing dark utilities when the user selects light mode

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d80f55cd44832b8cebc3b418e65950