### PR TITLE
Fix reminder effect referencing undefined view

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -308,7 +308,7 @@ const App: React.FC = () => {
   }, [showCelebration]);
 
   useEffect(() => {
-    if (view !== View.Learning) {
+    if (currentViewKey !== 'Learning') {
       return;
     }
 
@@ -316,7 +316,7 @@ const App: React.FC = () => {
       localStorage.setItem('palabrita_last_reminder_dismissed', new Date().toISOString());
     }
     setShowReminder(false);
-  }, [view]);
+  }, [currentViewKey]);
 
   const handleThemeChange = useCallback((preference: ThemePreference) => {
     setSettings(prev => ({ ...prev, themePreference: preference }));


### PR DESCRIPTION
## Summary
- replace the reminder dismissal effect to use the current view key instead of an undefined variable

## Testing
- npm run build *(fails: Rollup failed to resolve import "react-router-dom" from index.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68d84d906e94832bb49810498d77548b