### PR TITLE
Implement adaptive spaced repetition and configurable session mix

### DIFF
--- a/components/Flashcard.tsx
+++ b/components/Flashcard.tsx
@@ -1,11 +1,12 @@
 
 import React, { useState } from 'react';
 import type { Word } from '../types';
+import { ReviewQuality } from '../types';
 import Icon from './common/Icon';
 
 interface FlashcardProps {
   word: Word;
-  onAnswer: (correct: boolean) => void;
+  onAnswer: (quality: ReviewQuality) => void;
 }
 
 const Flashcard: React.FC<FlashcardProps> = ({ word, onAnswer }) => {
@@ -18,11 +19,11 @@ const Flashcard: React.FC<FlashcardProps> = ({ word, onAnswer }) => {
     }
   };
 
-  const handleGrade = (correct: boolean) => {
+  const handleGrade = (quality: ReviewQuality) => {
     setIsAnswered(true);
     // Add a short delay to see the feedback before the next card loads
     setTimeout(() => {
-        onAnswer(correct);
+        onAnswer(quality);
         setIsFlipped(false);
         setIsAnswered(false);
     }, 500);
@@ -54,16 +55,28 @@ const Flashcard: React.FC<FlashcardProps> = ({ word, onAnswer }) => {
             </div>
             <div className="mt-6">
               <p className="text-sm text-slate-500 dark:text-slate-400 mb-3">Hur bra kan du detta ord?</p>
-              <div className="flex justify-center space-x-3">
+              <div className="grid grid-cols-2 gap-3">
                 <button
-                  onClick={(e) => { e.stopPropagation(); handleGrade(false); }}
-                  className="flex-1 py-3 px-4 bg-red-100 dark:bg-red-500/20 text-red-700 dark:text-red-200 rounded-lg font-semibold hover:bg-red-200 dark:hover:bg-red-500/30 transition-colors"
+                  onClick={(e) => { e.stopPropagation(); handleGrade(ReviewQuality.Again); }}
+                  className="py-3 px-4 bg-red-100 dark:bg-red-500/20 text-red-700 dark:text-red-200 rounded-lg font-semibold hover:bg-red-200 dark:hover:bg-red-500/30 transition-colors"
+                >
+                  Igen
+                </button>
+                <button
+                  onClick={(e) => { e.stopPropagation(); handleGrade(ReviewQuality.Hard); }}
+                  className="py-3 px-4 bg-amber-100 dark:bg-amber-500/20 text-amber-700 dark:text-amber-200 rounded-lg font-semibold hover:bg-amber-200 dark:hover:bg-amber-500/30 transition-colors"
                 >
                   Svårt
                 </button>
                 <button
-                  onClick={(e) => { e.stopPropagation(); handleGrade(true); }}
-                  className="flex-1 py-3 px-4 bg-emerald-100 dark:bg-emerald-500/20 text-emerald-700 dark:text-emerald-200 rounded-lg font-semibold hover:bg-emerald-200 dark:hover:bg-emerald-500/30 transition-colors"
+                  onClick={(e) => { e.stopPropagation(); handleGrade(ReviewQuality.Good); }}
+                  className="py-3 px-4 bg-sky-100 dark:bg-sky-500/20 text-sky-700 dark:text-sky-200 rounded-lg font-semibold hover:bg-sky-200 dark:hover:bg-sky-500/30 transition-colors"
+                >
+                  Bra
+                </button>
+                <button
+                  onClick={(e) => { e.stopPropagation(); handleGrade(ReviewQuality.Easy); }}
+                  className="py-3 px-4 bg-emerald-100 dark:bg-emerald-500/20 text-emerald-700 dark:text-emerald-200 rounded-lg font-semibold hover:bg-emerald-200 dark:hover:bg-emerald-500/30 transition-colors"
                 >
                   Lätt
                 </button>

--- a/components/LearningSession.tsx
+++ b/components/LearningSession.tsx
@@ -1,22 +1,23 @@
 
 import React, { useState, useEffect } from 'react';
-import type { Word } from '../types';
+import type { Word, SessionResult } from '../types';
+import { ReviewQuality } from '../types';
 import Flashcard from './Flashcard';
 import ProgressBar from './common/ProgressBar';
 import Button from './common/Button';
 
 interface LearningSessionProps {
   words: Word[];
-  onSessionComplete: (sessionWords: { wordId: string; correct: boolean }[]) => void;
+  onSessionComplete: (sessionWords: SessionResult[]) => void;
 }
 
 const LearningSession: React.FC<LearningSessionProps> = ({ words, onSessionComplete }) => {
   const [currentIndex, setCurrentIndex] = useState(0);
-  const [sessionResults, setSessionResults] = useState<{ wordId: string; correct: boolean }[]>([]);
+  const [sessionResults, setSessionResults] = useState<SessionResult[]>([]);
   const [sessionFinished, setSessionFinished] = useState(false);
 
   const currentWord = words[currentIndex];
-  const progress = (currentIndex / words.length) * 100;
+  const progress = words.length > 0 ? (currentIndex / words.length) * 100 : 0;
 
   useEffect(() => {
     if (words.length === 0) {
@@ -24,8 +25,12 @@ const LearningSession: React.FC<LearningSessionProps> = ({ words, onSessionCompl
     }
   }, [words]);
 
-  const handleAnswer = (correct: boolean) => {
-    const newResults = [...sessionResults, { wordId: currentWord.id, correct }];
+  const handleAnswer = (quality: ReviewQuality) => {
+    if (!currentWord) {
+      return;
+    }
+
+    const newResults = [...sessionResults, { wordId: currentWord.id, quality }];
     setSessionResults(newResults);
 
     if (currentIndex < words.length - 1) {
@@ -36,7 +41,7 @@ const LearningSession: React.FC<LearningSessionProps> = ({ words, onSessionCompl
   };
 
   if (sessionFinished) {
-    const correctCount = sessionResults.filter(r => r.correct).length;
+    const correctCount = sessionResults.filter(r => r.quality >= ReviewQuality.Good).length;
     const totalCount = words.length;
 
     return (

--- a/components/Settings.tsx
+++ b/components/Settings.tsx
@@ -8,6 +8,8 @@ interface SettingsProps {
   onToggleReminders: (enabled: boolean) => void;
   onToggleConfetti: (enabled: boolean) => void;
   onDailyGoalChange: (goal: number) => void;
+  onSessionSizeChange: (size: number) => void;
+  onNewWordsRatioChange: (ratio: number) => void;
 }
 
 const themeOptions: { label: string; value: ThemePreference; description: string }[] = [
@@ -22,6 +24,8 @@ const Settings: React.FC<SettingsProps> = ({
   onToggleReminders,
   onToggleConfetti,
   onDailyGoalChange,
+  onSessionSizeChange,
+  onNewWordsRatioChange,
 }) => {
   return (
     <div className="space-y-6">
@@ -76,6 +80,48 @@ const Settings: React.FC<SettingsProps> = ({
             />
             <p className="text-xs text-slate-500 dark:text-slate-400 mt-1">
               Hur många ord vill du repetera varje dag?
+            </p>
+          </div>
+          <div className="pt-6 mt-6 border-t border-slate-100 dark:border-slate-800">
+            <div className="flex items-center justify-between">
+              <label htmlFor="session-size" className="text-sm font-medium text-slate-700 dark:text-slate-200">
+                Ord per session
+              </label>
+              <span className="text-sm text-slate-500 dark:text-slate-400">{settings.sessionSize} kort</span>
+            </div>
+            <input
+              id="session-size"
+              type="range"
+              min={5}
+              max={20}
+              step={1}
+              value={settings.sessionSize}
+              onChange={(event) => onSessionSizeChange(Number(event.target.value))}
+              className="w-full mt-3 accent-indigo-600"
+            />
+            <p className="text-xs text-slate-500 dark:text-slate-400 mt-1">
+              Anpassa hur långa lektionspass du vill ha.
+            </p>
+          </div>
+          <div className="pt-6 mt-6 border-t border-slate-100 dark:border-slate-800">
+            <div className="flex items-center justify-between">
+              <label htmlFor="new-words-ratio" className="text-sm font-medium text-slate-700 dark:text-slate-200">
+                Andel nya ord
+              </label>
+              <span className="text-sm text-slate-500 dark:text-slate-400">{settings.newWordsRatio}%</span>
+            </div>
+            <input
+              id="new-words-ratio"
+              type="range"
+              min={0}
+              max={100}
+              step={5}
+              value={settings.newWordsRatio}
+              onChange={(event) => onNewWordsRatioChange(Number(event.target.value))}
+              className="w-full mt-3 accent-indigo-600"
+            />
+            <p className="text-xs text-slate-500 dark:text-slate-400 mt-1">
+              Styr balansen mellan repetition och nytt innehåll i dina pass.
             </p>
           </div>
         </div>

--- a/services/wordService.ts
+++ b/services/wordService.ts
@@ -20,5 +20,8 @@ export const getInitialWords = async (): Promise<Word[]> => {
       exampleSentence: wordData.sentence_es,
       masteryLevel: MasteryLevel.New,
       nextReviewDate: now,
+      easeFactor: 2.5,
+      repetitionCount: 0,
+      reviewInterval: 0,
     }));
 };

--- a/types.ts
+++ b/types.ts
@@ -9,6 +9,9 @@ export interface Word {
   masteryLevel: MasteryLevel;
   nextReviewDate: string; // ISO string
   learnedDate?: string; // ISO string
+  easeFactor: number;
+  repetitionCount: number;
+  reviewInterval: number;
 }
 
 export enum MasteryLevel {
@@ -41,6 +44,20 @@ export interface AppSettings {
   remindersEnabled: boolean;
   enableConfetti: boolean;
   dailyGoal: number;
+  sessionSize: number;
+  newWordsRatio: number;
+}
+
+export enum ReviewQuality {
+  Again = 0,
+  Hard = 3,
+  Good = 4,
+  Easy = 5,
+}
+
+export interface SessionResult {
+  wordId: string;
+  quality: ReviewQuality;
 }
 
 export interface Achievement {


### PR DESCRIPTION
## Summary
- add SM-2-inspired spaced repetition fields and review processing with multiple answer options
- allow learners to configure session size and balance of new versus review cards via settings
- update flashcards and learning sessions to capture review quality and drive the adaptive schedule

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d84a3a7ce4832b9a15d1e221782a1c