### PR TITLE
Restore indigo primary color

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -863,7 +863,7 @@ const App: React.FC = () => {
                 <button
                     key={key}
                     onClick={() => handleNavigation(key)}
-                    className={`p-2 rounded-lg transition-colors ${currentViewKey === key ? 'text-pink-600 dark:text-pink-300 bg-pink-50 dark:bg-pink-500/10' : 'text-slate-500 dark:text-slate-400 hover:bg-slate-100 dark:hover:bg-slate-800/70'}`}
+                    className={`p-2 rounded-lg transition-colors ${currentViewKey === key ? 'text-indigo-600 dark:text-indigo-300 bg-indigo-50 dark:bg-indigo-500/10' : 'text-slate-500 dark:text-slate-400 hover:bg-slate-100 dark:hover:bg-slate-800/70'}`}
                 >
                     {View[key]}
                 </button>

--- a/components/Settings.tsx
+++ b/components/Settings.tsx
@@ -43,10 +43,10 @@ const Settings: React.FC<SettingsProps> = ({
                   key={option.value}
                   type="button"
                   onClick={() => onThemeChange(option.value)}
-                  className={`flex-1 text-left p-4 rounded-2xl border transition-colors focus:outline-none focus:ring-2 focus:ring-pink-500 focus:ring-offset-2 dark:focus:ring-offset-slate-900 ${
+                  className={`flex-1 text-left p-4 rounded-2xl border transition-colors focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 dark:focus:ring-offset-slate-900 ${
                     isActive
-                      ? 'border-pink-500 bg-pink-50 text-pink-700 shadow-sm dark:bg-pink-500/10 dark:border-pink-400'
-                      : 'border-slate-200 bg-white hover:border-pink-300 hover:bg-pink-50/40 dark:border-slate-700 dark:bg-transparent dark:hover:border-pink-500/80 dark:hover:bg-pink-500/5'
+                      ? 'border-indigo-500 bg-indigo-50 text-indigo-700 shadow-sm dark:bg-indigo-500/10 dark:border-indigo-400'
+                      : 'border-slate-200 bg-white hover:border-indigo-300 hover:bg-indigo-50/40 dark:border-slate-700 dark:bg-transparent dark:hover:border-indigo-500/80 dark:hover:bg-indigo-500/5'
                   }`}
                 >
                   <div className="font-semibold">{option.label}</div>

--- a/components/UpdateNotification.tsx
+++ b/components/UpdateNotification.tsx
@@ -10,7 +10,7 @@ const UpdateNotification: React.FC<UpdateNotificationProps> = ({ onUpdate }) => 
       <p className="text-slate-700 dark:text-slate-200">En ny version finns tillgänglig.</p>
       <button
         onClick={onUpdate}
-        className="bg-pink-600 text-white dark:bg-pink-500 dark:text-white px-4 py-2 rounded-lg hover:bg-pink-500 dark:hover:bg-pink-400 transition-colors"
+        className="bg-indigo-600 text-white dark:bg-indigo-500 dark:text-white px-4 py-2 rounded-lg hover:bg-indigo-500 dark:hover:bg-indigo-400 transition-colors"
       >
         Ladda om
       </button>

--- a/components/common/Button.tsx
+++ b/components/common/Button.tsx
@@ -9,11 +9,11 @@ const Button: React.FC<ButtonProps> = ({ children, className = '', ...props }) =
   return (
     <button
       className={`
-        w-full bg-pink-600 text-white dark:bg-pink-500 dark:text-white font-semibold py-3 px-6 rounded-lg
-        shadow-sm hover:bg-pink-500 dark:hover:bg-pink-400
-        focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-pink-500 dark:focus:ring-pink-400 dark:focus:ring-offset-slate-900
+        w-full bg-indigo-600 text-white dark:bg-indigo-500 dark:text-white font-semibold py-3 px-6 rounded-lg
+        shadow-sm hover:bg-indigo-500 dark:hover:bg-indigo-400
+        focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 dark:focus:ring-indigo-400 dark:focus:ring-offset-slate-900
         transition-all duration-200 ease-in-out transform active:scale-95
-        disabled:bg-pink-200 dark:disabled:bg-pink-900/40 disabled:text-white/70 disabled:cursor-not-allowed disabled:shadow-none disabled:scale-100
+        disabled:bg-indigo-200 dark:disabled:bg-indigo-900/40 disabled:text-white/70 disabled:cursor-not-allowed disabled:shadow-none disabled:scale-100
         ${className}
       `}
       {...props}


### PR DESCRIPTION
## Summary
- revert navigation bar and theme selector accents back to the indigo primary color
- update shared button and update notification styling to use the indigo palette instead of pink

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f708fa46c832b8747ca81f4d79291)